### PR TITLE
[Admin] Added GitHub Documentation to the Repo

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,45 @@
+# Documentation
+
+The documentation for this project is broken down by team. Each team is in charge of creating and maintaining their own documentation.
+
+## This Repo's Version Control System
+
+**Primary Owner:** @andrewdimmer
+
+**Secondary Owners:** @ProjectSCRUMMaster, @ProjectAssistantSCRUMMaster
+
+This repo contains the work of 5 independant sprint teams. To streamline the work follow, increase automation and transparency, and decrease friction between teams, this repo is configured to protect the `main` line to prevent breaking other teams.
+
+For more information, and trainings, check out the [version-control](version-control/) docs.
+
+## Project
+
+**Primary Owner:** The Professor
+
+**Secondary Owners:** @andrewdimmer, @ProjectSCRUMMaster, @ProjectAssistantSCRUMMaster
+
+This will contain the important docs regarding the project description and project scope, reposted here so that hopefully people have an easier time finding and referencing them than on Moodle.
+
+## Practice
+
+**Primary Owner:** @andrewdimmer
+
+**Secondary Owners:** @ProjectSCRUMMaster, @ProjectAssistantSCRUMMaster
+
+This will contain any sample practice exercises to have you get familiar with Git, GitHub, and the workflow of how we're managing this project.
+
+[Click here to access the practice exercise!](practice/)
+
+## Admin
+
+## Integration
+
+## Display_01
+
+## Display_02
+
+## Middleware_01
+
+## Middleware_02
+
+## Database

--- a/docs/version-control/CodeReviews.md
+++ b/docs/version-control/CodeReviews.md
@@ -1,0 +1,144 @@
+# Version Control Documentation - Code Reviews (CRs)
+
+[<-- Return to Version Control Documentation Hub](README.md)
+
+We talked about requesting a "Code Review (CR)" in our documentation on [Writing Code and Pull Requests (PRs)](WritingCode.md), but how do you give a CR? Below, we'll go over the steps that you need to give awesome CRs!
+
+## What are "Code Reviews (CRs)"?
+
+They are exactly what the name says: someone goes through and reviews the code that has been added to a "Pull Request (PR)", and either Approves, Comments on, or Requests changes.
+
+During the CR, reviewer look to make sure that everything looks correct syntactically, that the code follows the style guide, and there aren't any bugs in it that they can see.
+
+## What should I look for as a code reviewer?
+
+Your job is to basically fine tooth comb the whole PR, and basically make sure that it is "high quality" code going into production. Things to look for include:
+
+- Syntax errors
+- Logical errors
+- Style issues
+- Data type issues (ex. variable x is an int, but maybe it should be a float?)
+- Typos
+- Out of date documentation (like comments)
+- Bad permissions (ex. attribute X should be private and use getters and setters instead of being public)
+- Places to reduce code duplication
+- Places to improve efficiency
+- Places to maybe use a better code pattern
+- etc.
+
+For this project as well, it might also be worth checking some of the PR content, like:
+
+- Does the PR name start with [TEAM_NAME]?
+- Does the description link to the feature request or bug report issue(s)?
+- Are the correct assignees on the PR?
+- Are the correct labels added?
+- Is the PR added to the STSB and the correct milestone?
+- etc.
+
+## How do I make a "Code Review (CR)"?
+
+1. Open the repository at GitHub.com.
+
+2. Click on the "Pull requests" tab in the **menu bar directly below the repository name (black text on a grey background)**! DO NOT click the "Pull requests" tab in the top menu bar (grey text on a black background); this is for all of the pull requests that you have open in all repos, we just need the PRs for this repo.
+
+3. Select the PR you want to add a CR to from the list. Note: you can [use filters](Issues.md#im-trying-to-find-an-issue-or-pr-how-can-i-filter-and-search-for-it) to help find the PR you're looking for in the list.
+
+4. If you are marked as a reviewer, then there is usually a yellow banner above the PR title that says "This pull request is waiting on your review." If that bar is there, you can click on the green "Add your review" button, and it will take you directly to the "Files changed" page. If you are not a reviewer, you can still add a review by clicking on the "Files changed" tab directly below the PR title. Note: If the PR is still in a draft status (the oval below the title is grey and says "Draft" instead of being green and saying "Open"), you can still add a review (they system doesn't stop you), but just know the changes are not final yet and are likely still under development.
+
+5. Add your comments and suggestions to the code directly (see below for different options). You can also mark the files as viewed, to help keep track of what you've seen, even if you didn't need to leave any comments on it (see below for how to do this). Note: for some files, you may need to click the "Load diff" button to view the changes.
+
+6. Once you've added all of your comments and viewed all of your files, it's time to officially create your review! At the top right corner of the "Files changed", click the green "Review changes" button. That will bring up a box where you can enter a final comment, and select either "Approve", "Comment", or "Request changes".
+
+7. While not required, most people do leave a final comment on the review, typically regarding the final status (anything from "Looks good, ship it!" to "Good start, but I've left some comments of things to take care of before we can merge.").
+
+8. Then, select the "approval level". If you approve it, then once all the other required reviews are approved the PR is good to merge! If you just comment, it doesn't block a merge if other people approve it, but it also doesn't count towards having reviewer approvals. Finally, if you request changes, then the PR cannot be merged until the assignee makes changes and you approve the PR.
+
+9. Finally, click the green "Submit review" button.
+
+You've now added a CR to a PR! Once the rest of the reviewers approve it, the assignee can merge it to `main` and send the code into production!
+
+The below sections provide more detail about step 5 above, and the different ways you can do this.
+
+Want a video tutorial? Check out [GitHub Crash Course: Creating Code Reviews](https://youtu.be/GbjI2x0dMK0)!
+
+### How can I create a comment?
+
+From the "Files changed" tab:
+
+1. Hover over a line of code (you may need to click the "Load diff" button to view the changes).
+
+2. Click the blue "+" that occurs on the left side of the by the line number.
+
+3. Add your comment to the text box.
+
+4. Click the green "Start a review" or "Add review comment" button. You CAN create a comment directly by clicking "Add single comment", but it's really, really rare that there is only 1 single comment on the whole PR, AND you don't care if it gets resolved or not, AND you aren't required as a reviewer anyways. Unless all of those conditions are true, it's better to just create a review (even if it is just a "Comment" review), as it reduces the notifications sent to the assignee makes everything a bit easier.
+
+Want a video tutorial? Check out [GitHub Crash Course: Creating Code Reviews](https://youtu.be/GbjI2x0dMK0)!
+
+### Can I create a single comment about multiple lines of code?
+
+Yes, you can! To do so from the "Files changed" tab:
+
+1. Hover over a line of code (you may need to click the "Load diff" button to view the changes).
+
+2. Click AND HOLD the blue "+" that occurs on the left side of the by the line number.
+
+3. Press the "Shift" key
+
+4. Click and drag the mouse until all of the lines you want to comment on are highlighted
+
+5. Release the left mouse button.
+
+6. Add your comment to the text box.
+
+7. Click the green "Start a review" or "Add review comment" button. You CAN create a comment directly by clicking "Add single comment", but it's really, really rare that there is only 1 single comment on the whole PR, AND you don't care if it gets resolved or not, AND you aren't required as a reviewer anyways. Unless all of those conditions are true, it's better to just create a review (even if it is just a "Comment" review), as it reduces the notifications sent to the assignee makes everything a bit easier.
+
+Want a video tutorial? Check out [GitHub Crash Course: Creating Code Reviews](https://youtu.be/GbjI2x0dMK0)!
+
+### Can I make suggestions directly?
+
+Feel that there is a change that it would be faster for you just to implement than it would be to explain it? You can add it as a suggestion! To add a suggestion to a comment (either single or multiline):
+
+1. Make sure the comment is on a green line of code (you can't add suggestions to code that is being deleted).
+
+2. Press the little page icon with a "+" and a "-" in it on the far-left side of the edit menu (just to the left of heading, bold, and italics).
+
+3. Make your proposed code change.
+
+4. Continue adding content to the comment around the "suggestion block" that was just added.
+
+5. Post the comment, and the suggestion will then allow the assigning to merge it directly!
+
+Want a video tutorial? Check out [GitHub Crash Course: Creating Code Reviews](https://youtu.be/GbjI2x0dMK0)!
+
+### How can I keep track of files I've seen?
+
+Code reviews can be long! Fortunately, you can mark which files you've seen by clicking the "Viewed" checkbox on the far-right side of the file name bar for each file in the "Files changed" tab.
+
+Want a video tutorial? Check out [GitHub Crash Course: Creating Code Reviews](https://youtu.be/GbjI2x0dMK0)!
+
+## Help! Changes were requested on my PR! What do I do?
+
+At its simplest: follow the directions given to you in the comments, make/"Push" the changes to the PR or Code, and send it back for review.
+
+That being said, there are a number of helpful techniques you can use to help keep track of everything as you're making changes:
+
+1. Reply to comments as you go. It's much easier to write and commit chucks of code at once, but post as soon as you've made a change so you don't need to keep going back to the change and see what the next steps are. This is especially great if you disagree with the comment; this is your chance to start a conversation and figure out the best path forward!
+
+2. Resolve conversions once you've made a change. This collapses them down so they don't create as much cluttering.
+
+3. View your comments with more context in the "Files changed" tab (found right below PR title).
+
+4. Once you've finished updating a file, or if there were no comments on file, you can mark it as "Viewed" on the "Files changed" tab to hide the whole file from view (you can maximize it again later if you want by either expanding it on the left, or unchecking viewed.) To mark a file as viewed, click the "Viewed" checkbox on the far-right side of the file name bar for each file in the "Files changed" tab.
+
+5. "Commit" suggestions. Suggestions are great because the reviewer already did your work for you! Just click the "Add suggestion to batch" button! Then once all of the suggestions you want to accept have been added to the batch, you can click the "Commit suggestions" button, give your commit a descriptive tile and description, then click the green "Commit" button. It's that easy!
+
+Final note regarding making changes to a PR based on a CR: it's usually helpful to reach out to the reviewers again after you make the changes, just so they know that you're ready to go for another round of reviews!
+
+Want a video tutorial? Check out [GitHub Crash Course: Responding to Code Reviews](https://youtu.be/vSsUO_OP-f8)!
+
+## What's next?
+
+| Previous                                                   |                                                      Next |
+| :--------------------------------------------------------- | --------------------------------------------------------: |
+| [<-- Writing Code and Pull Requests (PRs)](WritingCode.md) | [Issues: Bug Reports and Feature Requests -->](Issues.md) |

--- a/docs/version-control/GitHubProjects.md
+++ b/docs/version-control/GitHubProjects.md
@@ -1,0 +1,49 @@
+# Version Control Documentation - GitHub Projects: The Sprint Task Status Board
+
+[<-- Return to Version Control Documentation Hub](README.md)
+
+When we've talked about creating issues and pull requests in the past, we've always had a step to set the project and the milestone. But what are they, and how do we use them? Below, we'll go over all of this!
+
+## What are "GitHub Projects"?
+
+A GitHub Project is simply a visualize issues, pull requests, and notes into swimlanes. This allows us to easily make things like a Sprint Task Status Board (STSB), or a bug triage board. Because these boards are also tied directly to the issues and pull requests themselves, they can be configured with basic automation to move issues and pull requests from one swimlane to another each time their status changes.
+
+## How do I view a project like the Sprint Task Status Board?
+
+1. Open the repository at GitHub.com.
+
+2. Click on the "Projects" tab in the menu bar directly below the repository name.
+
+3. Select the project board you want to see from the list.
+
+You can also use the "Open" and "Closed" toggle to switch between viewing open and closed project boards.
+
+Want a video tutorial? Check out [GitHub Crash Course: Projects and Milestones](https://youtu.be/6G9LzEyFrhE)!
+
+## How to I move issues and pull requests from one status to another?
+
+Thanks to GitHub's automation rules, you really shouldn't need to! Each issue and pull request will move itself to the correct status based on the status of that issue or pull request itself.
+
+In the off chance that you do need to manually move something though, you can do so by simply clicking and dragging.
+
+## What is a "Milestone"?
+
+A milestone is just an arbitrary collection of issues and pull requests that represents typically something like a feature release. In this case, we'll be using them to track where we need to be by the end of each sprint (i.e. what code needs to be done before our next demo).
+
+## "I'm trying to find an Issue or PR on a GitHub Project Board. How can I filter and search for it?"
+
+From within a project board, you can simply click on different attributes to filter by it. These include but are not limited to:
+
+- Clicking on your team's label to see everything assigned to your team
+- Clicking on a milestone to see everything that needs to be done by that deadline
+- Clicking on yourself to see everything assigned to you
+
+You can also search and filter using the filter bar in the top, right-hand corner of the project board.
+
+Want a video tutorial? Check out [GitHub Crash Course: Projects and Milestones](https://youtu.be/6G9LzEyFrhE)!
+
+## What's next?
+
+| Previous                                                  |                                               Next |
+| :-------------------------------------------------------- | -------------------------------------------------: |
+| [<-- Issues: Bug Reports and Feature Requests](Issues.md) | [Version Control Documentation Hub -->](README.md) |

--- a/docs/version-control/Issues.md
+++ b/docs/version-control/Issues.md
@@ -1,0 +1,121 @@
+# Version Control Documentation - Issues: Bug Reports and Feature Requests
+
+[<-- Return to Version Control Documentation Hub](README.md)
+
+We briefly mentioned issues when talking about [Writing Code and Pull Requests (PRs)](WritingCode.md), but what are they, and how do we use them? Below, we'll go over all of this, as well as how we'll be using them!
+
+## What are "Issues"?
+
+At their simplest, they are simply a "post" (for lack of a better word) on a GitHub repository. In terms of what they are physically, they are a block of text that we can reply to in comments, add labels to, and mark them open or closed. Unlike PRs and CRs, Issues don't directly relate to any code that we've written (unless someone copies and pastes in a code snippet to a comment or the description).
+
+Where issues become powerful though is in the fact we can use them as a centralizing "thread" for all the work that is going on regarding a certain topic. In large, open source repositories, they can host anything and everything to do with a project, from a feature roadmap, to a deprecation notice and sunset plan, to support tickets.
+
+What they're most known for (and what we'll use them for), however, is being able to have end users report bugs and make feature requests, then automatically update interested users when a developer starts working on a resolution for the issue. Remember when we mentioned that PRs should have a description containing "Working on #X..." where X was the issue number of the sprint story? By doing so, it means that any time a developer creates a PR and links the issue like that, or pushes a commit with the issue number, GitHub tracks it to the issue thread so you can see all of those as a timeline at once.
+
+We'll also be using Issues because they automatically integrate with GitHub Projects, which we can use to automate our Sprint Task Status Board (SPSB).
+
+That said, there are four main use cases for how we'll be using issues (and one extra piece of helpful info):
+
+1. ["Help! I found a bug or missing documentation! How can I report it to the team that needs to fix it?"](#help-i-found-a-bug-or-missing-documentation-how-can-i-report-it-to-the-team-that-needs-to-fix-it)
+
+2. ["I'm fixing a bug or missing documentation. How do I track my progress?"](#im-fixing-a-bug-or-missing-documentation-how-do-i-track-my-progress)
+
+3. ["I need to add a Product Backlog Item (PBI) to the SPSB. How do I do this?"](#i-need-to-add-a-product-backlog-item-pbi-to-the-spsb-how-do-i-do-this)
+
+4. ["I'm working on a sprint task. How do I track it?"](#im-working-on-a-sprint-task-how-do-i-track-it)
+
+5. ["I'm trying to find an Issue or PR. How can I filter and search for it?"](#im-trying-to-find-an-issue-or-pr-how-can-i-filter-and-search-for-it)
+
+## "Help! I found a bug or missing documentation! How can I report it to the team that needs to fix it?"
+
+1. Open the repository at GitHub.com.
+
+2. Click on the "Issues" tab in the **menu bar directly below the repository name (black text on a grey background)**! DO NOT click the "Issues" tab in the top menu bar (grey text on a black background); this is for all of the issues that you have open in all repos, we just need the issues for this repo.
+
+3. Click the green "New issue" in the top-right corner of the screen.
+
+4. Find the template that best fits your need. It will most likely be "[TEAM_NAME] Bug Report" or "[TEAM_NAME] Documentation Request". Then click the green "Get started" button.
+
+5. Give the issue a descriptive title after the "[TEAM_NAME]". For example, if you were asking for more documentation on issues, you could create an issue called "[Admin] Clarify documentation on GitHub issues".
+
+6. Complete each section of the description to the best of your ability.
+
+7. Click the gear icon next to "Projects" in the right column, and select the "Sprint Task Status Board (STSB)".
+
+8. Click the gear icon next to "Milestone" in the right column, and select the correct sprint that it is due in. (In the very rare chance that it isn't due, select the "Miscellaneous" milestone, but that should really only be if we don't need to show it in the project demo, and if that's the case, why do it at all?)
+
+9. Click the green "Submit new issue" button at the bottom of the description box.
+
+You've now submitted an issue to that team! It's now up to them to assign it out and prioritize it with their other work. When in doubt, feel free to conversations about the issue in the issue comments.
+
+Note: this is great to not only report issues for other teams, but also self-report issues. Found a bug in code that someone else wrote? Create an issue for it, then just add them as the assignee and let them know. The issue will do the rest of the tracking for you regarding progress.
+
+Want a video tutorial? Check out [GitHub Crash Course: Issues (Feature Request and Bug Reports)](https://youtu.be/j1-xU6bmZZg)!
+
+## "I'm fixing a bug or missing documentation. How do I track my progress?"
+
+If you're just "claiming" the issue, then all you need to do is make sure that you are the assignee, and remove any old assignees on the issue. You can also add a comment on the issue saying that you're working on it, but depending on the urgency of the issue that may or may not be required.
+
+Then, you can make all of the changes, following the instructions given on [Writing Code and Pull Requests (PRs)](WritingCode.md). Once again, feel free to add any comments to the issue if required as your working, but for most issues it should just be a simple matter of resolving it by fixing the bug or adding the documentation.
+
+Finally, so long as you include "Fixed #X" where X is the issue number, once the PR is merged, the issue will automatically close.
+
+Want a video tutorial? Check out [GitHub Crash Course: Issues (Feature Request and Bug Reports)](https://youtu.be/j1-xU6bmZZg)!
+
+## "I need to add a Product Backlog Item (PBI) to the SPSB. How do I do this?"
+
+1. Open the repository at GitHub.com.
+
+2. Click on the "Issues" tab in the **menu bar directly below the repository name (black text on a grey background)**! DO NOT click the "Issues" tab in the top menu bar (grey text on a black background); this is for all of the issues that you have open in all repos, we just need the issues for this repo.
+
+3. Click the green "New issue" in the top-right corner of the screen.
+
+4. Find the template that best fits your need. It will most likely be "[TEAM_NAME] Project Backlog Item". Then click the green "Get started" button.
+
+5. Give the issue a descriptive title after the "[TEAM_NAME]". For example, if you were asking for more documentation on issues, you could create an issue called "[Admin] Clarify documentation on GitHub issues".
+
+6. Complete each section of the description to the best of your ability. Note that for the tasks, those will become checkboxes that you can actually check, uncheck, and reorder once the issue is created!
+
+7. Click the gear icon next to "Projects" in the right column, and select the "Sprint Task Status Board (STSB)".
+
+8. Click the gear icon next to "Milestone" in the right column, and select the correct sprint that it is due in. (In the very rare chance that it isn't due, select the "Miscellaneous" milestone, but that should really only be if we don't need to show it in the project demo, and if that's the case, why do it at all?)
+
+9. Click the green "Submit new issue" button at the bottom of the description box.
+
+You've now recorded your PBI, and can start working on those tasks!
+
+Want a video tutorial? Check out [GitHub Crash Course: Issues (Feature Request and Bug Reports)](https://youtu.be/j1-xU6bmZZg)!
+
+## "I'm working on a sprint task. How do I track it?"
+
+First, you make all of the changes you need to for a task (or part of a task), following the instructions given on [Writing Code and Pull Requests (PRs)](WritingCode.md). Feel free to add any comments to the issue if required as your working, but for most issues it should just be a simple matter of just doing the task.
+
+Then, so long as you include "Working on #X - Y" where X is the issue number and Y is the task your working on, once the PR is merged, the issue will add the PR to the worklog. If you include the specific task Y you're working on, you shouldn't need any comments at this stage either.
+
+Finally, once you are done with your task, check the box saying it is done in the issue description. If you're completing the last task of the issue, you can also click the "Close issue" button at the bottom of the issue, and you're all set!
+
+Want a video tutorial? Check out [GitHub Crash Course: Issues (Feature Request and Bug Reports)](https://youtu.be/j1-xU6bmZZg)!
+
+## "I'm trying to find an Issue or PR. How can I filter and search for it?"
+
+1. Open the repository at GitHub.com.
+
+2. Click on the "Issues" or "Pull requests" tab in the **menu bar directly below the repository name (black text on a grey background)**! DO NOT click the "Issues" or "Pull requests" tab in the top menu bar (grey text on a black background); this is for all of the issues or pull requests that you have open in all repos, we just need the issues for this repo.
+
+3. Add your filters via the filters bar and the bar directly above the issues or pull requests list. These include but are not limited to:
+
+- From the "Filters" dropdown: "Your pull requests" --> All open pull requests that you created
+- From the "Filters" dropdown: "Everything assigned to you" --> All open issues and pull request where you are an assignee (this would be your team's issues and your personal PRs for the most part)
+- From the "Filters" dropdown: "Everything mentioning you" --> All open issues and pull request for all users in the repo where you are included as an assignee, code reviewer, commenter, etc.
+- From the "Label" dropdown: You can select your team's label to see all open issues or pull requests belonging to your team
+- From the "Milestones" dropdown: You can filter by task due date (so only show me those due next sprint)
+- From the "Reviewers" dropdown: You can select all open pull requests where you are a reviewer
+- From the search bar next to the "Filters" dropdown: You can flat out search for an issue or pull request
+
+You can also use the "Open" and "Closed" toggle to switch between viewing open and closed issues and pull requests.
+
+## What's next?
+
+| Previous                                 |                                                                   Next |
+| :--------------------------------------- | ---------------------------------------------------------------------: |
+| [<-- Code Reviews (CRs)](CodeReviews.md) | [GitHub Projects: The Sprint Task Status Board -->](GitHubProjects.md) |

--- a/docs/version-control/README.md
+++ b/docs/version-control/README.md
@@ -1,0 +1,37 @@
+# Version Control Documentation - Hub
+
+## Why is contributing this repository so complex?
+
+Whenever working on production code in industry, one of the main goals is to not break it for other people working on it. This is done by isolating changes to different Git branches, then enforcing code reviews and testing before merging.
+
+While this project is not an industry project by any means, we also have almost 50 developers working on it at once, on a really short timeline to get everything done before the end of the semester. Nobody wants to spend their time trying to figure out why the project won't build anymore, just to find out that one person on another team accidently blocked the whole thing from building (we're also programming from the command line, so let's be real, this is a real possibility).
+
+Therefore, just like industry automates checks and puts processes in place to keep production services up and running, we'll do the same.
+
+What about things like issues, projects, milestones, and labels? While these don't protect the project, they serve to increase transparency as to what other teams are working on, and reduce the amount of manual paperwork everyone does.
+
+By tracking each of the Product Backlog Items (PBIs) as issues, we can automatically generate the Sprint Task Status Board (STSB), and automatically keep it up to date via GitHub projects. This replaces the need for us to download an Excel STSB from Moodle, add our updates, then reupload it before the next person makes another change. Milestones allow us to track goals against the sprint deadlines, and automatically generate a release to demo to the professor at the end of each sprint. And final labels and naming conventions allow us to manage what teams are working on what when, and who is responsible for what parts of the project at a glance.
+
+Want a video introduction? Check out [GitHub Crash Course: An Introduction to Version Control](https://youtu.be/gIFwvJ0sqnU)!
+
+## This sounds hard! How can I learn what to do?
+
+Never fear, while it may sound like a lot, it shouldn't be that much more work. And the goal here is to use systems so that you only need to spend a little time keeping things up to date, instead of a ton of time fixing stuff when it breaks.
+
+With all that in mind, there should be clear documentation on how to do everything you need to do, as well as video tutorials for doing most of it!
+
+For ease of readability, all of this content has been split into different sections, so you can quickly find what you need.
+
+Click the links below to go to the documentation on each of the different tasks you may need to do throughout the project:
+
+1. [Writing Code and Pull Requests (PRs)](WritingCode.md)
+
+2. [Code Reviews (CRs)](CodeReviews.md)
+
+3. [Issues: Bug Reports and Feature Requests](Issues.md)
+
+4. [GitHub Projects: The Sprint Task Status Board](GitHubProjects.md)
+
+## Want a video tutorial?
+
+In each section, there will be a link to the pertinent video tutorial, but you can watch the whole [GitHub Crash Course](https://www.youtube.com/playlist?list=PLxX-LBwfD3eseUIGAPg63CE-W_2h8zIIx) from the playlist as well!

--- a/docs/version-control/WritingCode.md
+++ b/docs/version-control/WritingCode.md
@@ -1,0 +1,213 @@
+# Version Control Documentation - Writing Code and Pull Requests (PRs)
+
+[<-- Return to Version Control Documentation Hub](README.md)
+
+Below, we'll go over the steps that you need to do to write and save code to GitHub!
+
+## How do I get the code to my computer?
+
+1. To download the code to your computer, you must first install a git client. In most cases, if you are new to GitHub and Git, it's easiest to start with [GitHub Desktop](https://desktop.github.com/). You can also use the git CLI (Mac and Linux), git bash (windows), or [GitKraken](https://www.gitkraken.com/) (for more advanced GUI features).
+
+2. "Clone" this repository from your preferred git client to whatever directory you are going to work out of.
+
+Want a video tutorial? Check out [GitHub Crash Course: Cloning a GitHub Repository](https://youtu.be/VPSPYHuahvY)!
+
+## How do I write new code?
+
+Prerequsites: Make sure you are on the `main` branch of the repository, then right before starting this process be sure you "Pull" the `main` branch to get any new updates!
+
+1. Create a new branch from your preferred git client. This basically creating a new copy of the code that is yours to use. This means that if anyone else changes code, it won't break what your making while you're still writing your code. (Note: it may still break your code later, but we'll fix this later on).
+
+2. Open the code repository in your preferred development environment (i.e. JEdit for this class).
+
+3. Make your code changes, and save any file's you've changed when you're done.
+
+4. "Pull" the branch of the code repository via your preferred git client. This checks if there are any files that have been updated on the branch since you last got the source code. If you know that you are the only person who is working on the branch, you can technically skip this step, but it's still recommended just in case. If both you and your partner for the programming pairs are both writing code back and forth, this is required (or you'll get error later on; we can fix it, but it's more difficult).
+
+5. "Stage" the files that you want to upload to GitHub in your preferred git client. This basically tells Git that you're going to save these files soon (think of it like opening the Save As menu on something like a Word document for a whole bunch of files at once). Note that you can change files but NOT save them to GitHub if you're just making something like a temporary change to a variable in another class to test your own.
+
+6. "Commit" your changes to the "Git Tree" (i.e. the version history of something like a Google Doc) via your preferred git client. In our example of the Word documents above, this is when you actually click the save button. Be sure to give it a descriptive commit title, and a description if required! Note that only you and your teammates will see these commits, so there is no "required" naming convention, but I would recommend [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0-beta.4/) if you're team wants to use a naming convention. This makes tracking what was changed when for code reviews (to be explained later) and when looking back at the repository history much easier!
+
+7. "Push" your new commit(s) to GitHub via your preferred git client. This is the equivalent of uploading your newly changed code (or Word document in our running example) to the server. Before you "Push" the changes are saved, but ONLY exist on your local machine. It's best practice to "Push" after EVERY commit, although if you forget you can just multiple at once later without an error.
+
+8. [RECOMMENDED]: [Create a "Pull Request (PR)" via GitHub.com](#how-do-i-create-a-pull-request-pr). Note that while this is technically not required YET, by creating a "Pull Request" now, it automatically adds that your task is "In Progress" on the STSB. This allows you automatically keep your Team SCRUM manager up to date with your progress, as well as your teammates and other teams that may depend on your code.
+
+9. Repeat steps 3-7 until you're done working on your current feature or bug fix. This should be repeated until your code is the point that you're ready to "Ship" your feature, so you shouldn't stop until the code is building and passing all unit test.
+
+Once your code is ready to "Ship", the next step is to [Create a "Pull Request (PR)" via GitHub.com](#how-do-i-create-a-pull-request-pr) if you have not already done so, or [Request "Code Reviews (CRs) via GitHub.com"](#how-do-i-request-code-reviews-crs).
+
+Want a video tutorial? Check out [GitHub Crash Course: Writing Code to GitHub](https://youtu.be/M_O4TRYA8FU)!
+
+### How often should I "Commit"?
+
+Just like you want to save any changes to a document frequently, you want to "Commit" frequently as well. The unofficial phrase you'll find online is "Commit Early, Commit Often" (great advice for Git, but unadvisable for dating :) ).
+
+Why should you "Commit Early, Commit Often"? There are a number of reasons but the top 3 are:
+
+1. Make small, bit-sized backups in case something breaks or you decide to redesign something: Git only saves your work when you commit, so if you write 300 lines of the code, then find a bug and need to go back to what you had, you are out all 300 lines of code. If you make 10 smaller commits, then you can just roll back to the last point you had good code without losing all of your progress.
+
+2. Increased clarity for code reviews and repository history: Just saying "I edited a class and fixed a bug" doesn't mean anything to anyone but you. If you go through and say "Updated variable x datatype", "Added new helper method y", "Refactored and updated documentation for z", everyone reading that can understand your thought process, what changes you made, and why you made them.
+
+3. Increase transparency for your work progress: by committing and pushing your code frequently, it lets you start it, take a break, come back to it later, and then take another break without the rest of your team wonder what is happening. It also means that your teammates which may depend on your code can see drafts while you're still writing it.
+
+Because we're using Test Driven Development (TDD), I would recommend AT LEAST 2-4 commits for each time you make a new test:
+
+1. The test itself
+
+2. The bare minimum code to pass that test
+
+3. A refactor to reduce code duplication
+
+4. Any documentation updates
+
+Want a video explanation? Check out [GitHub Crash Course: Is There Such Thing as Too Many Commits?](https://youtu.be/fN5Yq_pVl5w)!
+
+### Can I "Commit" too often?
+
+No! One of the reasons that we're requiring pull requests in this repository is that we use a tool called "Squash and Merge", which means that no matter how many commits you make internally, there is only one that moves into the `main` branch.
+
+This effectively means that with each commit you are making the CHANGELOG of what you've worked on. For example, if you have three commits "Added a unit test for task x", "Wrote method y to pass test x", "Refactored method z into y", the final commit on the `main` branch will read:
+
+- Added a unit test for task x
+- Wrote method y to pass test x
+- Refactored method z into y
+
+This means that anyone who sees your new code on the `main` branch can see exactly what you did without even looking at their code, so they can know if it impacts them! This is even more helpful when you are working on multiple methods and classes to complete a single change.
+
+Want a video explanation? Check out [GitHub Crash Course: Is There Such Thing as Too Many Commits?](https://youtu.be/fN5Yq_pVl5w)!
+
+## How do I ship what I'm working on so my teammates and other teams can use it?
+
+When we talked about creating a branch, we mentioned that by working on a separate branch other people's changes can't break your code. But by that same token, they can't access your changes in their code either. So how do you make your code accessible to everyone else? The end goal is to "Merge" in into the `main` branch of the repository, which is all the code that is done and in production. To do that, we have a 3.5 step process:
+
+1. Create a "Pull Request (PR)"
+
+2. Request "Code Reviews (CRs)" (and step 2.5 verify that all "Checks" pass)
+
+3. "Merge" your code into the `main` branch
+
+In this section, we'll focus on creating a "Pull Request (PR)", and will come back to the rest a little later.
+
+### What is a "Pull Request (PR)"?
+
+A "Pull Request (PR)" is essentially a process to formally declare that you want to release your code to the `main` branch (or another branch).
+
+It serves as a central place to track all of the individual commits that make up a single change in one place, a place to have conversations about how things are implemented and what is in progress, and a "complete version" of code to have others review and run though testing.
+
+Last but not least, it a way to document what is in progress and what the status is for a particular task. Everything on the PR automatically syncs to the STSB, so if you do your pull request well, this does all the tracking tasks that you need to do for you!
+
+### How do I create a "Pull Request (PR)"?
+
+1. Open the repository at GitHub.com.
+
+2. Click on the "Pull requests" tab in the **menu bar directly below the repository name (black text on a grey background)**! DO NOT click the "Pull requests" tab in the top menu bar (grey text on a black background); this is for all of the pull requests that you have open in all repos, we just need the PRs for this repo.
+
+3. Click the green "New pull request" in the top-right corner of the screen.
+
+4. Check that the "base" is set to `main` (unless you are merging into another branch, but this is really rare).
+
+5. Select the name of your branch in the "compare" dropdown menu.
+
+6. Click the green "Create pull request" button.
+
+7. Give your PR a name. This should start with [Your_Team] (ex. [Middleware_01]), then have a descriptive name for what you are changing (this is just like a commit title from when you were writing code).
+
+8. In the first line of the description (where it says "Leave a comment"), explain what you were working on. If you are working in a sprint task, this should be in the form "Working on #X - Y" where X is the issue number of the sprint task, and Y is the specific subtask(s) this pull request works on or completes. If you're working on a bug fix, the first line of the description should simply read "Fixed #X" where X is the issue with the bug (this will automatically link the bug to the PR for you!). If you are fixing multiple bugs or features at once, add them on additional lines with the same format as above. This syncs up what you are working on with the issue that lives in the "To Do" swimlane of the STSB.
+
+9. Add any extra description about what you changed or did. Note that in most cases if you "Commit Early, Commit Often", you probably won't need to add anything else here because your commits (which you can see below the description box) will already include all the information that you need.
+
+10. Click the gear icon next to "Assignees" in the right column, and select everyone who is assigned to write the code for this PR. This will at least include you, and may also include your programming partner if both of you are pushing code. Note that only one of you needs to create the PR, even if both of you are pushing code.
+
+11. Click the gear icon next to "Labels" in the right column, and select the appropriate labels for the PR. For our project, this will be the name of your team (ex. "Middleware_01"), and at least one "type" label (bug, enhancement, or documentation). Note that if you are making a bug fix, select "bug". If you are working on code for a sprint item, select "enhancement". If you are working on documentation, select "documentation". If your task does multiple of these, feel free to select all of them that apply!
+
+12. Click the gear icon next to "Projects" in the right column, and select the "Sprint Task Status Board (STSB)".
+
+13. Click the gear icon next to "Milestone" in the right column, and select the correct sprint that it is due in. (In the very rare chance that it isn't due, select the "Miscellaneous" milestone, but that should really only be if we don't need to show it in the project demo, and if that's the case, why do it at all?)
+
+14. Click the dropdown arrow to the right of "Create pull request".
+
+15. Select "Draft pull request" from the dropdown menu.
+
+16. Click the green "Draft pull request" button.
+
+You've now published your PR! You can either keep coding if you're still working on your task(s) that you need to do before you can merge, or [Request "Code Reviews (CRs)"](#how-do-i-request-code-reviews-crs).
+
+Note, if you want to come back to your pull request and edit it later, or even just check back on its status, you can do so by completing steps 1 and 2 above, then selecting your pull request from the list. You can [use filters](Issues.md#im-trying-to-find-an-issue-or-pr-how-can-i-filter-and-search-for-it) to help find your PR in the list.
+
+Want a video tutorial? Check out [GitHub Crash Course: Creating Pull Requests](https://youtu.be/3Q1MZjAVIiE)!
+
+## How do I check my code is ready to "Merge"?
+
+As mentioned earlier, you need to get "Code Reviews (CRs)" and pass all the "Checks" in order to merge your code to the `main` branch.
+
+### What are "Checks"?
+
+"Checks" are automated workflows that GitHub runs to validate that your PR is in good shape to merge. The main one will be a build test via Gradle: if the code builds and passes unit tests, the check approves the PR; otherwise, it blocks it from being merged.
+
+### What do I do if a "Check" failed?
+
+From your PR:
+
+1. Click on the "Checks" tab below the PR title
+
+2. View the checks that failed, and each task should be a description of what the check verifies
+
+3. Fix the issue (either in the Code and push it to the PR, or within the PR itself)
+
+Want a video tutorial? Check out [GitHub Crash Course: Checks and Bots](https://youtu.be/rLciVQY9ejI)!
+
+### What are "Code Reviews (CRs)"?
+
+They are exactly what the name says: someone goes through and reviews the code that you've written in a PR, and either Approves, Comments on, or Requests changes.
+
+During the code review, reviewer look to make sure that everything looks correct syntactically, that the code follows the style guide, and there aren't any bugs in it that they can see.
+
+### Who do I need to review my code?
+
+You need at least to CR approvals before you can "Merge" your code. These are intended to be your programming partner and either your Team SCRUM Master or Team Assistant SCRUM Master.
+
+Note: by default, GitHub should automatically add both your Team SCRUM Master and Team Assistant SCRUM Master as reviewers when you publish your PR. You'll only need one of their approvals to merge, but if one of them requests changes, then you must gain their approval to merge.
+
+### What happens if one of my reviewers requests changes?
+
+That's totally fine, and happens all the time in industry. If they request changes, it just means you need to make some changes then they will review it again.
+
+If you do have changes requested, the reviewer should have left you either global comments or comments on specific parts of your code that you need to take another look at. Once you fix those changes, and push the code up, just let your reviewers know and they'll give it another look.
+
+Want extra tips to make resolving requested changes even easier? Take a look at the ["Help! Changes were requested on my PR! What do I do?"](CodeReviews.md#help-changes-were-requested-on-my-pr-what-do-i-do) section of the Code Reviews documentation.
+
+### How do I request "Code Reviews (CRs)"?
+
+From your PR:
+
+1. Click the gear icon next to "Reviewers" in the right column, and select the appropriate reviewers for the PR. In most cases, this will be your programming partner, and either your Team SCRUM Master or Team Assistant SCRUM Master.
+
+2. At the bottom of your PR, click the grey "Ready for review" next to the line that says "This pull request is still a work in progress".
+
+It's that easy! Now you just need to wait for your reviews to review your code, and you can either "Merge" it if they approve, or go back and make changes if they didn't.
+
+Want a video tutorial? Check out [GitHub Crash Course: Requesting Code Reviews](https://youtu.be/FjrDgBOS_20)!
+
+## How do I "Merge" my code?
+
+Finally, it's time to "Merge" your code into the `main` branch so that everyone else can use it, and it can be deployed to production.
+
+Once all of your CRs are in the approval state, and all your checks pass, from your PR:
+
+1. At the bottom of your PR, click the green "Squash and Merge" button.
+
+2. Review the merge commit (it should be good if your PR was filled out correctly).
+
+3. Click the green "Confirm squash and merge".
+
+Want a video tutorial? Check out [GitHub Crash Course: Merging Pull Requests](https://youtu.be/6Kbly2r-g60)!
+
+There you go! You're codes now in production! If you were working off of a subtask for an issue, you can now [check that off](Issues.md#im-working-on-a-sprint-task-how-do-i-track-it)! If you were fixing a bug, the issue should have automatically closed when the PR was merged because we linked the issue to the PR!
+
+Finally, be sure to switch back to the `main` branch again before starting this process again!
+
+## What's next?
+
+| Previous                                           |                                     Next |
+| :------------------------------------------------- | ---------------------------------------: |
+| [<-- Version Control Documentation Hub](README.md) | [Code Reviews (CRs) -->](CodeReviews.md) |


### PR DESCRIPTION
Working on #1 - Add GitHub Documentation for Reference

More or less the same was what was in the practice repo at https://github.com/andrewdimmer/csi-3370-software-project-config-test/tree/main/docs/version-control.